### PR TITLE
Make pandera enum checks optional

### DIFF
--- a/src/matrix_schema/__init__.py
+++ b/src/matrix_schema/__init__.py
@@ -1,0 +1,1 @@
+"""Matrix Schema package."""

--- a/src/matrix_schema/utils/__init__.py
+++ b/src/matrix_schema/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Matrix Schema utilities."""

--- a/src/matrix_schema/utils/generate_biolink_imports.py
+++ b/src/matrix_schema/utils/generate_biolink_imports.py
@@ -1,0 +1,93 @@
+from typing import List, Dict
+from linkml_runtime import SchemaView
+from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.formatutils import camelcase, underscore
+from linkml_runtime.dumpers import yaml_dumper
+import importlib.resources
+from linkml_runtime.linkml_model import (
+    EnumDefinition,
+    PermissibleValue)
+
+
+PREDICATE_ROOT = "related to"
+NODE_CATEGORY_ROOT = "named thing"
+BIOLINK_IMPORT_SCHEMA_FILE = "biolink_imports.yaml"
+
+
+class FlatteningExtractor():
+    
+    def __init__(self, sv: SchemaView):
+        self.sv = sv
+
+    def generate_enum(self, name: str, title_to_value_mapping: Dict[str, str]) -> EnumDefinition:        
+        permissible_values = [
+            PermissibleValue(title=title, text=value) 
+            for title, value in title_to_value_mapping.items()
+        ]
+        enum = EnumDefinition(name=name, permissible_values=permissible_values)
+        return enum        
+
+    def generate_enum_from_slot_descendants(self, name: str, root_slot: str) -> EnumDefinition:
+        values = {}
+        for slot in self.sv.slot_descendants(root_slot):
+            title = underscore(slot).upper()
+            value = self.sv.schema.default_prefix + ":" + underscore(slot)
+            values[title] = value
+        return self.generate_enum(name, values)
+
+    def generate_enum_from_class_descendants(self, name: str, root_class: str) -> EnumDefinition:
+        values = {}
+        for cls in self.sv.class_descendants(root_class):
+            title = underscore(cls).upper()
+            value = self.sv.schema.default_prefix + ":" + camelcase(cls)
+            values[title] = value
+        return self.generate_enum(name, values)
+
+def get_biolink_model_schemaview() -> SchemaView:
+    # Locate the YAML file for the biolink model within the biolink_model package
+    biolink_model_file = importlib.resources.files("biolink_model.schema").joinpath(
+        "biolink_model.yaml"
+    )
+    return SchemaView(str(biolink_model_file)) 
+
+def generate_biolink_enum_schema():
+    sv = get_biolink_model_schemaview()
+    fe = FlatteningExtractor(sv)
+    # Create the schema builder
+    sb = SchemaBuilder("biolink_enum")
+    sb.schema.default_prefix = "matrix_schema"
+    sb.schema.id = "https://w3id.org/everycure-org/matrix-schema/biolink_imports"
+    sb.schema.description = "Biolink model enums for the matrix schema"
+    sb.schema.license = "BSD-3"
+
+    # Add all predicate values as an enum for the predicate slot in the matrix schema
+    sb.add_enum(
+        fe.generate_enum_from_slot_descendants(
+            name="PredicateEnum",
+            root_slot=PREDICATE_ROOT
+        )
+    )
+    
+    # Add all node category values as an enum for the node category slot in the matrix schema
+    sb.add_enum(
+        fe.generate_enum_from_class_descendants(
+            name="NodeCategoryEnum",
+            root_class=NODE_CATEGORY_ROOT
+        )
+    )
+
+    # Additionally, bring over KL & AT enums from the biolink model, stripping subsets that aren't defined here    
+    knowledge_level_enum = sv.get_enum("KnowledgeLevelEnum")
+    knowledge_level_enum.in_subset = []
+    sb.add_enum(knowledge_level_enum)
+
+    agent_type_enum = sv.get_enum("AgentTypeEnum")
+    agent_type_enum.in_subset = []
+    sb.add_enum(agent_type_enum)
+    
+    output_path = "src/matrix_schema/schema/" + BIOLINK_IMPORT_SCHEMA_FILE
+    with open(output_path, "w") as f:
+        f.write(yaml_dumper.dumps(sb.schema))
+        
+
+generate_biolink_enum_schema()

--- a/src/matrix_schema/utils/generate_valid_edge_type_table.py
+++ b/src/matrix_schema/utils/generate_valid_edge_type_table.py
@@ -1,0 +1,73 @@
+from linkml_runtime.utils.schemaview import SchemaView
+import pandas as pd
+from matrix_schema.utils.generate_biolink_imports import get_biolink_model_schemaview
+
+VALID_EDGE_TYPE_TABLE = "valid_biolink_edge_types.tsv"
+
+def generate_valid_biolink_edge_types():
+    """
+    Generate a table of valid edge types for the Biolink model.
+    This includes both predicate-based and class definition-based edge types.
+
+    """
+    sv = get_biolink_model_schemaview()
+
+    predicate_valid_triples = []
+
+    predicates = sv.slot_descendants('related to')
+    for predicate in predicates:
+        slot = sv.get_slot(predicate)
+        
+        all_subject_categories = [sv.get_uri(class_name) for class_name in sv.class_descendants(slot.domain)] if slot.domain else None
+        all_object_categories = [sv.get_uri(class_name) for class_name in sv.class_descendants(slot.range)] if slot.range else None
+        if all_subject_categories and all_object_categories:
+            for subject_category in all_subject_categories:
+                for object_category in all_object_categories:
+                    predicate_valid_triples.append({
+                        "subject_category": subject_category,
+                        "predicate": sv.get_uri(predicate),
+                        "object_category": object_category
+                    })
+
+    class_definition_valid_triples = []
+
+    for class_name in sv.class_descendants('association'):
+        cls = sv.get_class(class_name)
+        slot_usage = cls.slot_usage
+        if slot_usage is None: 
+            continue 
+        if 'subject' not in slot_usage or slot_usage['subject'] is None or slot_usage['subject'].range is None:
+            continue
+        if 'predicate' not in slot_usage or slot_usage['predicate'].subproperty_of is None:
+            continue
+        if 'object' not in slot_usage or slot_usage['object'] is None or slot_usage['object'].range is None:
+            continue
+            
+
+        subject_range = slot_usage['subject'].range
+        all_subject_categories = [sv.get_uri(class_name) for class_name in sv.class_descendants(subject_range)]         
+        all_predicates = [sv.get_uri(predicate_name) for predicate_name in sv.slot_descendants(slot_usage['predicate'].subproperty_of)]
+        object_range = slot_usage['object'].range
+        all_object_categories = [sv.get_uri(class_name) for class_name in sv.class_descendants(object_range)]
+        for subject_category in all_subject_categories:
+            for predicate in all_predicates:
+                for object_category in all_object_categories:
+                    class_definition_valid_triples.append({
+                        "subject_category": subject_category,
+                        "predicate": predicate,
+                        "object_category": object_category
+                    })
+
+
+
+    predicate_valid_triples_df = pd.DataFrame(predicate_valid_triples)
+    association_valid_triples_df = pd.DataFrame(class_definition_valid_triples)
+    all_valid_triples_df = pd.merge(predicate_valid_triples_df, association_valid_triples_df, 
+                                    how='outer', on=['subject_category','predicate', 'object_category'])
+
+    output_path = "src/matrix_schema/schema/" + VALID_EDGE_TYPE_TABLE    
+    all_valid_triples_df.to_csv(output_path, sep='\t', index=False)
+
+
+if __name__ == "__main__":
+    generate_valid_biolink_edge_types()

--- a/src/matrix_schema/utils/pandera_utils.py
+++ b/src/matrix_schema/utils/pandera_utils.py
@@ -78,20 +78,15 @@ class DataFrameSchema:
 
 
 def check_output(
-    schema: typing.Union[DataFrameSchema, typing.Callable], 
-    df_name: Optional[str] = None, 
-    raise_df_undefined: bool = True, 
-    pass_columns: bool = False,
-    validate_enumeration_values: bool = True
+    schema: DataFrameSchema, df_name: Optional[str] = None, raise_df_undefined: bool = True, pass_columns: bool = False
 ):
     """Decorator to validate output schema of decorated function.
 
     Args:
-        schema: Schema to validate or callable that returns a schema
+        schema: Schema to validate
         df_name (optional): name of output arg to validate
         raise_df_undefined: if set, ensures error is thrown if `df_name` is not defined
         pass_cols (optional): boolean indicating whether cols should be passed into callable
-        validate_enumeration_values: whether to validate enumeration values in schema
     """
 
     def decorator(func):
@@ -101,21 +96,15 @@ def check_output(
                 raise TypeError("No output typehint specified!")
 
             if df_name:
-                if not typing.get_origin(type_) is dict:
+                if typing.get_origin(type_) is not dict:
                     raise TypeError("Specified df_name arg, but function output typehint is not dict.")
 
                 type_ = typing.get_args(type_)[1]
 
-            # Get schema - either use provided schema or call schema factory function
-            if callable(schema):
-                df_schema_obj = schema(validate_enumeration_values=validate_enumeration_values)
-            else:
-                df_schema_obj = schema
-                
-            df_schema = df_schema_obj.build_for_type(type_)
+            df_schema = schema.build_for_type(type_)
 
             if pass_columns:
-                output = func(*args, **kwargs, cols=list(df_schema_obj.columns.keys()))
+                output = func(*args, **kwargs, cols=list(schema.columns.keys()))
             else:
                 output = func(*args, **kwargs)
 

--- a/tests/test_pandera_integration.py
+++ b/tests/test_pandera_integration.py
@@ -1,0 +1,159 @@
+"""Integration tests for Pandera schema with real example data."""
+import os
+import unittest
+import pandas as pd
+import yaml
+from typing import Dict, Any
+
+from matrix_schema.datamodel.pandera import get_matrix_node_schema, get_matrix_edge_schema
+
+
+class TestPanderaIntegration(unittest.TestCase):
+    """Integration tests using real example data files."""
+
+    def setUp(self):
+        """Set up paths to example data."""
+        self.root = os.path.join(os.path.dirname(__file__), '..')
+        self.data_dir = os.path.join(self.root, "src", "data", "examples", "valid")
+        
+        self.node_file = os.path.join(self.data_dir, "MatrixNodeList-001.yaml")
+        self.edge_file = os.path.join(self.data_dir, "MatrixEdgeList-001.yaml")
+
+    def load_yaml_data(self, file_path: str) -> Dict[str, Any]:
+        """Load YAML data from file."""
+        with open(file_path, 'r') as f:
+            return yaml.safe_load(f)
+
+    def test_real_node_data_validation(self):
+        """Test Pandera validation against real node example data."""
+        if not os.path.exists(self.node_file):
+            self.skipTest(f"Node example file not found: {self.node_file}")
+
+        # Load example data
+        data = self.load_yaml_data(self.node_file)
+        nodes = data.get('nodes', [])
+        
+        if not nodes:
+            self.skipTest("No nodes found in example data")
+
+        # Convert to DataFrame format expected by Pandera
+        df_data = {
+            'id': [],
+            'name': [],
+            'category': [],
+            'description': [],
+            'equivalent_identifiers': [],
+            'all_categories': [],
+            'publications': [],
+            'labels': [],
+            'international_resource_identifier': [],
+            'upstream_data_source': []
+        }
+
+        for node in nodes:
+            for key in df_data.keys():
+                df_data[key].append(node.get(key))
+
+        df = pd.DataFrame(df_data)
+        
+        # Validate with Pandera schema
+        schema = get_matrix_node_schema()
+        pandas_schema = schema.build_for_type(type(df))
+        try:
+            validated_df = pandas_schema.validate(df)
+            self.assertIsInstance(validated_df, pd.DataFrame)
+            self.assertEqual(len(validated_df), len(nodes))
+        except Exception as e:
+            self.fail(f"Real node data failed Pandera validation: {e}")
+
+    def test_real_edge_data_validation(self):
+        """Test Pandera validation against real edge example data."""
+        if not os.path.exists(self.edge_file):
+            self.skipTest(f"Edge example file not found: {self.edge_file}")
+
+        # Load example data
+        data = self.load_yaml_data(self.edge_file)
+        edges = data.get('edges', [])
+        
+        if not edges:
+            self.skipTest("No edges found in example data")
+
+        # Convert to DataFrame format expected by Pandera
+        df_data = {
+            'subject': [],
+            'predicate': [],
+            'object': [],
+            'knowledge_level': [],
+            'agent_type': [],
+            'primary_knowledge_source': [],
+            'aggregator_knowledge_source': [],
+            'publications': [],
+            'subject_aspect_qualifier': [],
+            'subject_direction_qualifier': [],
+            'object_aspect_qualifier': [],
+            'object_direction_qualifier': [],
+            'upstream_data_source': [],
+            'num_references': [],
+            'num_sentences': []
+        }
+
+        for edge in edges:
+            for key in df_data.keys():
+                df_data[key].append(edge.get(key))
+
+        df = pd.DataFrame(df_data)
+        
+        # Validate with Pandera schema
+        schema = get_matrix_edge_schema()
+        pandas_schema = schema.build_for_type(type(df))
+        try:
+            validated_df = pandas_schema.validate(df)
+            self.assertIsInstance(validated_df, pd.DataFrame)
+            self.assertEqual(len(validated_df), len(edges))
+        except Exception as e:
+            self.fail(f"Real edge data failed Pandera validation: {e}")
+
+    def test_enum_values_in_real_data(self):
+        """Test that enum values in real data are valid."""
+        # Test node categories
+        if os.path.exists(self.node_file):
+            data = self.load_yaml_data(self.node_file)
+            nodes = data.get('nodes', [])
+            
+            from matrix_schema.datamodel.matrix_schema_pydantic import NodeCategoryEnum
+            valid_categories = [cat.value for cat in NodeCategoryEnum]
+            
+            for node in nodes:
+                category = node.get('category')
+                if category:
+                    self.assertIn(category, valid_categories, 
+                                f"Invalid category in real data: {category}")
+
+        # Test edge predicates
+        if os.path.exists(self.edge_file):
+            data = self.load_yaml_data(self.edge_file)
+            edges = data.get('edges', [])
+            
+            from matrix_schema.datamodel.matrix_schema_pydantic import PredicateEnum, KnowledgeLevelEnum, AgentTypeEnum
+            valid_predicates = [pred.value for pred in PredicateEnum]
+            valid_knowledge_levels = [kl.value for kl in KnowledgeLevelEnum]
+            valid_agent_types = [at.value for at in AgentTypeEnum]
+            
+            for edge in edges:
+                predicate = edge.get('predicate')
+                if predicate:
+                    self.assertIn(predicate, valid_predicates,
+                                f"Invalid predicate in real data: {predicate}")
+                
+                knowledge_level = edge.get('knowledge_level')
+                if knowledge_level:
+                    self.assertIn(knowledge_level, valid_knowledge_levels,
+                                f"Invalid knowledge_level in real data: {knowledge_level}")
+                
+                agent_type = edge.get('agent_type')
+                if agent_type:
+                    self.assertIn(agent_type, valid_agent_types,
+                                f"Invalid agent_type in real data: {agent_type}")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pandera_pyspark.py
+++ b/tests/test_pandera_pyspark.py
@@ -1,0 +1,123 @@
+"""Test Pandera schema with PySpark DataFrames."""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from matrix_schema.datamodel.pandera import get_matrix_node_schema, get_matrix_edge_schema
+
+
+class TestPanderaPySpark(unittest.TestCase):
+    """Test Pandera schema with PySpark DataFrames."""
+
+    def setUp(self):
+        """Set up test data for PySpark."""
+        # Mock PySpark DataFrame data
+        self.valid_node_rows = [
+            {
+                "id": "example:Node001",
+                "name": "Aspirin",
+                "category": "biolink:Drug",
+                "description": "A drug used to reduce pain",
+                "equivalent_identifiers": ["CHEBI:15365"],
+                "all_categories": ["biolink:Drug"],
+                "publications": ["PMID:12345678"],
+                "labels": ["Acetylsalicylic Acid"],
+                "international_resource_identifier": "http://purl.obolibrary.org/obo/CHEBI_15365",
+                "upstream_data_source": ["DrugBank"]
+            }
+        ]
+
+        self.valid_edge_rows = [
+            {
+                "subject": "example:Node001",
+                "predicate": "biolink:treats",
+                "object": "example:Node002",
+                "knowledge_level": "knowledge_assertion",
+                "agent_type": "manual_agent",
+                "primary_knowledge_source": "infores:drugbank",
+                "aggregator_knowledge_source": ["infores:omim"],
+                "publications": ["PMID:98765432"],
+                "subject_aspect_qualifier": "mode of action",
+                "subject_direction_qualifier": "inhibits",
+                "object_aspect_qualifier": "treatment",
+                "object_direction_qualifier": "reduces",
+                "upstream_data_source": ["DrugBank"],
+                "num_references": 5,
+                "num_sentences": 3
+            }
+        ]
+
+    @patch('matrix_schema.datamodel.pandera.T')
+    def test_schema_types(self, mock_types):
+        """Test that schema uses correct PySpark types."""
+        # Mock PySpark types
+        mock_types.StringType.return_value = "StringType"
+        mock_types.IntegerType.return_value = "IntegerType"
+        mock_types.ArrayType.return_value = "ArrayType"
+
+        node_schema = get_matrix_node_schema()
+        edge_schema = get_matrix_edge_schema()
+
+        # Verify schemas were created
+        self.assertIsNotNone(node_schema)
+        self.assertIsNotNone(edge_schema)
+
+    def test_enum_validation_setup(self):
+        """Test that enum validation is properly configured."""
+        node_schema = get_matrix_node_schema()
+        edge_schema = get_matrix_edge_schema()
+
+        # Check that category column has validation
+        category_column = node_schema.columns.get("category")
+        self.assertIsNotNone(category_column)
+        self.assertTrue(hasattr(category_column, 'checks'))
+
+        # Check that predicate column has validation
+        predicate_column = edge_schema.columns.get("predicate")
+        self.assertIsNotNone(predicate_column)
+        self.assertTrue(hasattr(predicate_column, 'checks'))
+
+    def test_schema_structure(self):
+        """Test schema structure and required fields."""
+        node_schema = get_matrix_node_schema()
+        edge_schema = get_matrix_edge_schema()
+
+        # Check node schema has all expected columns
+        expected_node_columns = [
+            "id", "name", "category", "description", "equivalent_identifiers",
+            "all_categories", "publications", "labels", 
+            "international_resource_identifier", "upstream_data_source"
+        ]
+        for col in expected_node_columns:
+            self.assertIn(col, node_schema.columns)
+
+        # Check edge schema has all expected columns
+        expected_edge_columns = [
+            "subject", "predicate", "object", "knowledge_level", "agent_type",
+            "primary_knowledge_source", "aggregator_knowledge_source", "publications",
+            "subject_aspect_qualifier", "subject_direction_qualifier",
+            "object_aspect_qualifier", "object_direction_qualifier",
+            "upstream_data_source", "num_references", "num_sentences"
+        ]
+        for col in expected_edge_columns:
+            self.assertIn(col, edge_schema.columns)
+
+    def test_unique_constraints(self):
+        """Test unique constraints are configured."""
+        node_schema = get_matrix_node_schema()
+        edge_schema = get_matrix_edge_schema()
+
+        # Check unique constraints
+        self.assertEqual(node_schema.unique, ["id"])
+        self.assertEqual(edge_schema.unique, ["subject", "predicate", "object"])
+
+    def test_strict_mode(self):
+        """Test that schemas are configured in strict mode."""
+        node_schema = get_matrix_node_schema()
+        edge_schema = get_matrix_edge_schema()
+
+        self.assertTrue(node_schema.strict)
+        self.assertTrue(edge_schema.strict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pandera_schema.py
+++ b/tests/test_pandera_schema.py
@@ -1,0 +1,352 @@
+"""Test Pandera schema validation."""
+import unittest
+from unittest.mock import patch
+
+try:
+    import pandas as pd
+    import pyspark
+    from pyspark.sql import SparkSession
+    import pandera.pyspark as pa
+    from matrix_schema.datamodel.pandera import get_matrix_node_schema, get_matrix_edge_schema
+    DEPENDENCIES_AVAILABLE = True
+except ImportError as e:
+    DEPENDENCIES_AVAILABLE = False
+    SKIP_REASON = str(e)
+
+
+@unittest.skipUnless(DEPENDENCIES_AVAILABLE, f"Dependencies not available: {SKIP_REASON if not DEPENDENCIES_AVAILABLE else 'Unknown'}")
+class TestPanderaSchema(unittest.TestCase):
+    """Test Pandera schema validation."""
+
+    def setUp(self):
+        """Set up test data and minimal Spark session."""
+        # Create minimal Spark session for testing
+        self.spark = SparkSession.builder \
+            .appName("PanderaTest") \
+            .master("local[1]") \
+            .config("spark.driver.memory", "1g") \
+            .config("spark.executor.memory", "1g") \
+            .config("spark.sql.warehouse.dir", "/tmp/spark-warehouse") \
+            .getOrCreate()
+        
+        # Suppress verbose logging
+        self.spark.sparkContext.setLogLevel("WARN")
+        
+        # Valid node data
+        self.valid_node_data = {
+            "id": ["example:Node001", "example:Node002"],
+            "name": ["Aspirin", "Myocardial Infarction"],
+            "category": ["biolink:Drug", "biolink:Disease"],
+            "description": ["A drug used to reduce pain", "A heart condition"],
+            "equivalent_identifiers": [["CHEBI:15365"], ["MONDO:0005061"]],
+            "all_categories": [["biolink:Drug"], ["biolink:Disease"]],
+            "publications": [["PMID:12345678"], ["PMID:87654321"]],
+            "labels": [["Acetylsalicylic Acid"], ["Heart Attack"]],
+            "international_resource_identifier": [
+                "http://purl.obolibrary.org/obo/CHEBI_15365",
+                "http://purl.obolibrary.org/obo/MONDO_0005061"
+            ],
+            "upstream_data_source": [["DrugBank"], ["OMIM"]]
+        }
+
+        # Valid edge data
+        self.valid_edge_data = {
+            "subject": ["example:Node001", "example:Node002"],
+            "predicate": ["biolink:treats", "biolink:has_phenotype"],
+            "object": ["example:Node002", "example:Node003"],
+            "knowledge_level": ["knowledge_assertion", "prediction"],
+            "agent_type": ["manual_agent", "automated_agent"],
+            "primary_knowledge_source": ["infores:drugbank", "infores:omim"],
+            "aggregator_knowledge_source": [["infores:omim"], ["MONDO"]],
+            "publications": [["PMID:98765432"], ["PMID:56789012"]],
+            "subject_aspect_qualifier": ["mode of action", "disease manifestation"],
+            "subject_direction_qualifier": ["inhibits", None],
+            "object_aspect_qualifier": ["treatment", "molecular mechanism"],
+            "object_direction_qualifier": ["reduces", None],
+            "upstream_data_source": [["DrugBank"], ["OMIM"]],
+            "num_references": [5, 10],
+            "num_sentences": [3, 7]
+        }
+
+    def tearDown(self):
+        """Clean up Spark session."""
+        if hasattr(self, 'spark'):
+            self.spark.stop()
+
+    def test_valid_node_schema_pyspark(self):
+        """Test that valid node data passes validation with PySpark DataFrame."""
+        schema = get_matrix_node_schema()
+        
+        # Create PySpark DataFrame from pandas DataFrame
+        pandas_df = pd.DataFrame(self.valid_node_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Build schema for PySpark and validate
+        pyspark_schema = schema.build_for_type(type(spark_df))
+        
+        # This should not raise an exception
+        try:
+            validated_df = pyspark_schema.validate(spark_df)
+            self.assertIsNotNone(validated_df)
+        except Exception as e:
+            self.fail(f"Valid node data failed PySpark validation: {e}")
+
+    def test_valid_node_schema_pandas(self):
+        """Test that valid node data passes validation with pandas DataFrame."""
+        schema = get_matrix_node_schema()
+        
+        # Create pandas DataFrame
+        pandas_df = pd.DataFrame(self.valid_node_data)
+        
+        # Build schema for pandas and validate
+        pandas_schema = schema.build_for_type(type(pandas_df))
+        
+        # This should not raise an exception
+        try:
+            validated_df = pandas_schema.validate(pandas_df)
+            self.assertIsInstance(validated_df, pd.DataFrame)
+        except Exception as e:
+            self.fail(f"Valid node data failed pandas validation: {e}")
+
+    def test_valid_edge_schema_pyspark(self):
+        """Test that valid edge data passes validation with PySpark DataFrame."""
+        schema = get_matrix_edge_schema()
+        
+        # Create PySpark DataFrame from pandas DataFrame
+        pandas_df = pd.DataFrame(self.valid_edge_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Build schema for PySpark and validate
+        pyspark_schema = schema.build_for_type(type(spark_df))
+        
+        # This should not raise an exception
+        try:
+            validated_df = pyspark_schema.validate(spark_df)
+            self.assertIsNotNone(validated_df)
+        except Exception as e:
+            self.fail(f"Valid edge data failed PySpark validation: {e}")
+
+    def test_valid_edge_schema_pandas(self):
+        """Test that valid edge data passes validation with pandas DataFrame."""
+        schema = get_matrix_edge_schema()
+        
+        # Create pandas DataFrame
+        pandas_df = pd.DataFrame(self.valid_edge_data)
+        
+        # Build schema for pandas and validate
+        pandas_schema = schema.build_for_type(type(pandas_df))
+        
+        # This should not raise an exception
+        try:
+            validated_df = pandas_schema.validate(pandas_df)
+            self.assertIsInstance(validated_df, pd.DataFrame)
+        except Exception as e:
+            self.fail(f"Valid edge data failed pandas validation: {e}")
+
+    def test_invalid_node_category(self):
+        """Test that invalid node category fails validation with default settings but passes when disabled."""
+        invalid_data = self.valid_node_data.copy()
+        invalid_data["category"] = ["invalid:Category", "biolink:Disease"]
+        
+        pandas_df = pd.DataFrame(invalid_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Test with default validation (True) - should fail
+        strict_schema = get_matrix_node_schema(validate_enumeration_values=True)
+        pandas_strict_schema = strict_schema.build_for_type(type(pandas_df))
+        with self.assertRaises(Exception):
+            pandas_strict_schema.validate(pandas_df)
+        
+        # Test with validation disabled (False) - should pass
+        lenient_schema = get_matrix_node_schema(validate_enumeration_values=False)
+        pandas_lenient_schema = lenient_schema.build_for_type(type(pandas_df))
+        pyspark_lenient_schema = lenient_schema.build_for_type(type(spark_df))
+        
+        # These should not raise exceptions
+        validated_pandas_df = pandas_lenient_schema.validate(pandas_df)
+        validated_spark_df = pyspark_lenient_schema.validate(spark_df)
+        
+        self.assertIsInstance(validated_pandas_df, pd.DataFrame)
+        self.assertIsNotNone(validated_spark_df)
+
+    def test_invalid_edge_predicate(self):
+        """Test that invalid edge predicate fails validation with default settings but passes when disabled."""
+        invalid_data = self.valid_edge_data.copy()
+        invalid_data["predicate"] = ["invalid:predicate", "biolink:has_phenotype"]
+        
+        pandas_df = pd.DataFrame(invalid_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Test with default validation (True) - should fail
+        strict_schema = get_matrix_edge_schema(validate_enumeration_values=True)
+        pandas_strict_schema = strict_schema.build_for_type(type(pandas_df))
+        with self.assertRaises(Exception):
+            pandas_strict_schema.validate(pandas_df)
+        
+        # Test with validation disabled (False) - should pass
+        lenient_schema = get_matrix_edge_schema(validate_enumeration_values=False)
+        pandas_lenient_schema = lenient_schema.build_for_type(type(pandas_df))
+        pyspark_lenient_schema = lenient_schema.build_for_type(type(spark_df))
+        
+        # These should not raise exceptions
+        validated_pandas_df = pandas_lenient_schema.validate(pandas_df)
+        validated_spark_df = pyspark_lenient_schema.validate(spark_df)
+        
+        self.assertIsInstance(validated_pandas_df, pd.DataFrame)
+        self.assertIsNotNone(validated_spark_df)
+
+    def test_invalid_knowledge_level(self):
+        """Test that invalid knowledge level fails validation with default settings but passes when disabled."""
+        invalid_data = self.valid_edge_data.copy()
+        invalid_data["knowledge_level"] = ["invalid_level", "prediction"]
+        
+        pandas_df = pd.DataFrame(invalid_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Test with default validation (True) - should fail
+        strict_schema = get_matrix_edge_schema(validate_enumeration_values=True)
+        pandas_strict_schema = strict_schema.build_for_type(type(pandas_df))
+        with self.assertRaises(Exception):
+            pandas_strict_schema.validate(pandas_df)
+        
+        # Test with validation disabled (False) - should pass
+        lenient_schema = get_matrix_edge_schema(validate_enumeration_values=False)
+        pandas_lenient_schema = lenient_schema.build_for_type(type(pandas_df))
+        pyspark_lenient_schema = lenient_schema.build_for_type(type(spark_df))
+        
+        # These should not raise exceptions
+        validated_pandas_df = pandas_lenient_schema.validate(pandas_df)
+        validated_spark_df = pyspark_lenient_schema.validate(spark_df)
+        
+        self.assertIsInstance(validated_pandas_df, pd.DataFrame)
+        self.assertIsNotNone(validated_spark_df)
+
+    def test_missing_required_fields(self):
+        """Test that missing required fields fail validation."""
+        schema = get_matrix_node_schema()
+        invalid_data = self.valid_node_data.copy()
+        del invalid_data["id"]  # Remove required field
+        
+        pandas_df = pd.DataFrame(invalid_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        pyspark_schema = schema.build_for_type(type(spark_df))
+        
+        with self.assertRaises(Exception):
+            pyspark_schema.validate(spark_df)
+
+    def test_unique_constraints(self):
+        """Test that duplicate IDs fail validation."""
+        schema = get_matrix_node_schema()
+        invalid_data = self.valid_node_data.copy()
+        invalid_data["id"] = ["example:Node001", "example:Node001"]  # Duplicate IDs
+        
+        pandas_df = pd.DataFrame(invalid_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Test with pandas - this should work reliably
+        pandas_schema = schema.build_for_type(type(pandas_df))
+        with self.assertRaises(Exception):
+            pandas_schema.validate(pandas_df)
+        
+        # Test with PySpark - unique constraints may not be enforced
+        pyspark_schema = schema.build_for_type(type(spark_df))
+        try:
+            result = pyspark_schema.validate(spark_df)
+            print("WARNING: PySpark unique constraint validation may not be enforced - validation passed with duplicate IDs")
+        except Exception:
+            pass
+
+    def test_optional_enum_validation_node(self):
+        """Test that node schema with validate_enumeration_values=False accepts invalid categories."""
+        # Test with invalid category data
+        invalid_data = self.valid_node_data.copy()
+        invalid_data["category"] = ["invalid:Category", "another:InvalidCategory"]
+        
+        pandas_df = pd.DataFrame(invalid_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Should fail with default validation (True)
+        strict_schema = get_matrix_node_schema(validate_enumeration_values=True)
+        pandas_strict_schema = strict_schema.build_for_type(type(pandas_df))
+        with self.assertRaises(Exception):
+            pandas_strict_schema.validate(pandas_df)
+        
+        # Should pass with validation disabled (False)
+        lenient_schema = get_matrix_node_schema(validate_enumeration_values=False)
+        pandas_lenient_schema = lenient_schema.build_for_type(type(pandas_df))
+        pyspark_lenient_schema = lenient_schema.build_for_type(type(spark_df))
+        
+        # These should not raise exceptions
+        validated_pandas_df = pandas_lenient_schema.validate(pandas_df)
+        validated_spark_df = pyspark_lenient_schema.validate(spark_df)
+        
+        self.assertIsInstance(validated_pandas_df, pd.DataFrame)
+        self.assertIsNotNone(validated_spark_df)
+
+    def test_optional_enum_validation_edge(self):
+        """Test that edge schema with validate_enumeration_values=False accepts invalid enum values."""
+        # Test with invalid enum data
+        invalid_data = self.valid_edge_data.copy()
+        invalid_data["predicate"] = ["invalid:predicate", "another:invalid"]
+        invalid_data["knowledge_level"] = ["invalid_level", "another_invalid"]
+        invalid_data["agent_type"] = ["invalid_agent", "another_invalid"]
+        
+        pandas_df = pd.DataFrame(invalid_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        # Should fail with default validation (True)
+        strict_schema = get_matrix_edge_schema(validate_enumeration_values=True)
+        pandas_strict_schema = strict_schema.build_for_type(type(pandas_df))
+        with self.assertRaises(Exception):
+            pandas_strict_schema.validate(pandas_df)
+        
+        # Should pass with validation disabled (False)
+        lenient_schema = get_matrix_edge_schema(validate_enumeration_values=False)
+        pandas_lenient_schema = lenient_schema.build_for_type(type(pandas_df))
+        pyspark_lenient_schema = lenient_schema.build_for_type(type(spark_df))
+        
+        # These should not raise exceptions
+        validated_pandas_df = pandas_lenient_schema.validate(pandas_df)
+        validated_spark_df = pyspark_lenient_schema.validate(spark_df)
+        
+        self.assertIsInstance(validated_pandas_df, pd.DataFrame)
+        self.assertIsNotNone(validated_spark_df)
+
+    def test_schema_creation(self):
+        """Test that schema creation works."""
+        node_schema = get_matrix_node_schema()
+        edge_schema = get_matrix_edge_schema()
+        
+        self.assertIsNotNone(node_schema)
+        self.assertIsNotNone(edge_schema)
+        
+        # Test with both parameter values
+        node_schema_strict = get_matrix_node_schema(validate_enumeration_values=True)
+        node_schema_lenient = get_matrix_node_schema(validate_enumeration_values=False)
+        edge_schema_strict = get_matrix_edge_schema(validate_enumeration_values=True)
+        edge_schema_lenient = get_matrix_edge_schema(validate_enumeration_values=False)
+        
+        self.assertIsNotNone(node_schema_strict)
+        self.assertIsNotNone(node_schema_lenient)
+        self.assertIsNotNone(edge_schema_strict)
+        self.assertIsNotNone(edge_schema_lenient)
+        
+        # Check that schemas have expected columns
+        self.assertIn("id", node_schema.columns)
+        self.assertIn("category", node_schema.columns)
+        self.assertIn("subject", edge_schema.columns)
+        self.assertIn("predicate", edge_schema.columns)
+        
+        # Test that we can build both pandas and PySpark versions
+        pandas_df = pd.DataFrame(self.valid_node_data)
+        spark_df = self.spark.createDataFrame(pandas_df)
+        
+        pandas_node_schema = node_schema.build_for_type(type(pandas_df))
+        pyspark_node_schema = node_schema.build_for_type(type(spark_df))
+        
+        self.assertIsNotNone(pandas_node_schema)
+        self.assertIsNotNone(pyspark_node_schema)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- **make pandera enum value checks optional, check in untracked files that I missed earlier**
- **add support for passing a callable to get the schema, along with the boolean for validating enum values**
- **roll back to just having the enum value check as an argument to the schema getter functions**
