### PR TITLE
Update pandera.py

### DIFF
--- a/src/matrix_schema/datamodel/pandera.py
+++ b/src/matrix_schema/datamodel/pandera.py
@@ -158,7 +158,7 @@ def get_unioned_edge_schema(validate_enumeration_values: bool = True):
 
     return DataFrameSchema(
         columns={
-            "primary_knowledge_sources": Column(T.ArrayType(T.StringType()), nullable=False),
+            "primary_knowledge_sources": Column(T.ArrayType(T.StringType(), False), nullable=False),
             "subject": Column(T.StringType(), nullable=False),
             "predicate": Column(T.StringType(), nullable=False,
                               checks=predicate_checks),


### PR DESCRIPTION
## Update Pandera schema for `primary_knowledge_sources`

Update the Pandera schema for `primary_knowledge_sources` in `get_unioned_edge_schema` to align with Spark’s output from `collect_set`.

Current schema:
Column(T.ArrayType(T.StringType()), nullable=False)
This defaults to `containsNull=True`.

Spark output:
Using `collect_set` produces ArrayType(StringType(), False), which means array elements cannot be null.

Required change:
Column(T.ArrayType(T.StringType(), False), nullable=False)

Rationale:
This ensures schema validation passes when using:
F.collect_set(F.col("primary_knowledge_source")).alias("primary_knowledge_sources")